### PR TITLE
Redesigned the repository layer to better manage bulk operations

### DIFF
--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AspNetCore/Controllers/ObjectController.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AspNetCore/Controllers/ObjectController.cs
@@ -54,8 +54,17 @@ namespace Tardigrade.Framework.AspNetCore.Controllers
 
             try
             {
-                await service.DeleteAsync(id);
-                result = Ok();
+                T model = await service.RetrieveAsync(id);
+
+                if (model == null)
+                {
+                    result = NotFound();
+                }
+                else
+                {
+                    await service.DeleteAsync(model);
+                    result = Ok();
+                }
             }
             catch (ServiceException e)
             {
@@ -93,7 +102,6 @@ namespace Tardigrade.Framework.AspNetCore.Controllers
                 {
                     sortCondition = (q => q.OrderBy(o => o.Id));
                 }
-
             }
 
             if (!string.IsNullOrWhiteSpace(sortBy))

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AspNetCore/Tardigrade.Framework.AspNetCore.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AspNetCore/Tardigrade.Framework.AspNetCore.csproj
@@ -10,7 +10,7 @@
     <PackageProjectUrl>https://github.com/CaptainMesomorph/tardigrade-framework</PackageProjectUrl>
     <RepositoryUrl>https://github.com/CaptainMesomorph/tardigrade-framework</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AzureStorage/StorageTableRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AzureStorage/StorageTableRepository.cs
@@ -187,7 +187,7 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.CreateBulk(IEnumerable{T})"/>
+        /// <see cref="IBulkRepository{T}.CreateBulk(IEnumerable{T})"/>
         /// </summary>
         /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual IEnumerable<T> CreateBulk(IEnumerable<T> objs)
@@ -196,58 +196,12 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.CreateBulk(IEnumerable{T})"/>
+        /// <see cref="IBulkRepository{T}.CreateBulk(IEnumerable{T})"/>
         /// </summary>
         /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual Task<IEnumerable<T>> CreateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.Delete(PK)"/>
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The id parameter is null, or does not contain either a Partition Key or Row Key.</exception>
-        public virtual void Delete(PK id)
-        {
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            TableResult retrieveResult = GetRetrieveTableResult(id.Partition, id.Row);
-
-            if (retrieveResult.HttpStatusCode == (int)HttpStatusCode.OK)
-            {
-                // Assign the result to be deleted.
-                T deleteEntity = (T)retrieveResult.Result;
-
-                // Create the Delete TableOperation.
-                TableOperation deleteOperation = TableOperation.Delete(deleteEntity);
-
-                try
-                {
-                    // Execute the operation.
-                    TableResult deleteResult = table.ExecuteAsync(deleteOperation).GetAwaiter().GetResult();
-
-                    if (deleteResult.HttpStatusCode != (int)HttpStatusCode.OK)
-                    {
-                        throw new RepositoryException($"Delete failed; error code of {deleteResult.HttpStatusCode} was returned for object of type {typeof(T).Name} with Partition Key {id.Partition} and Row Key{id.Row} in Azure Storage Table {table.Name}.");
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new RepositoryException($"Delete failed; error deleting object of type {typeof(T).Name} with Partition Key {id.Partition} and Row Key{id.Row} from Azure Storage Table {table.Name} .", e);
-                }
-            }
-            else if (retrieveResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
-            {
-                throw new NotFoundException($"Delete failed; object of type {typeof(T).Name} with Partition Key {id.Partition} and Row Key{id.Row} does not exist in Azure Storage Table {table.Name}.");
-            }
-            else
-            {
-                throw new RepositoryException($"Delete failed; error code of {retrieveResult.HttpStatusCode} was returned for object of type {typeof(T).Name} with Partition Key {id.Partition} and Row Key{id.Row} in Azure Storage Table {table.Name}.");
-            }
         }
 
         /// <summary>
@@ -286,45 +240,6 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IRepository{T, PK}.DeleteAsync(PK, CancellationToken)"/>
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The id parameter is null, or does not contain either a Partition Key or Row Key.</exception>
-        public virtual async Task DeleteAsync(PK id, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            TableResult retrieveResult = await GetRetrieveTableResultAsync(id.Partition, id.Row);
-
-            if (retrieveResult.HttpStatusCode == (int)HttpStatusCode.OK)
-            {
-                // Assign the result to be deleted.
-                T deleteEntity = (T)retrieveResult.Result;
-
-                // Create the Delete TableOperation.
-                TableOperation deleteOperation = TableOperation.Delete(deleteEntity);
-
-                // Execute the operation.
-                TableResult deleteResult = await table.ExecuteAsync(deleteOperation);
-
-                if (deleteResult.HttpStatusCode != (int)HttpStatusCode.OK)
-                {
-                    throw new RepositoryException($"Delete failed; error code of {deleteResult.HttpStatusCode} was returned for object of type {typeof(T).Name} with Partition Key {id.Partition} and Row Key{id.Row} in Azure Storage Table {table.Name}.");
-                }
-            }
-            else if (retrieveResult.HttpStatusCode == (int)HttpStatusCode.NotFound)
-            {
-                throw new NotFoundException($"Delete failed; object of type {typeof(T).Name} with Partition Key {id.Partition} and Row Key{id.Row} does not exist in Azure Storage Table {table.Name}.");
-            }
-            else
-            {
-                throw new RepositoryException($"Delete failed; error code of {retrieveResult.HttpStatusCode} was returned for object of type {typeof(T).Name} with Partition Key {id.Partition} and Row Key{id.Row} in Azure Storage Table {table.Name}.");
-            }
-        }
-
-        /// <summary>
         /// <see cref="IRepository{T, PK}.DeleteAsync(T, CancellationToken)"/>
         /// </summary>
         /// <exception cref="ArgumentNullException">The obj parameter is null, or does not contain either a Partition Key or Row Key.</exception>
@@ -353,16 +268,7 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{PK})"/>
-        /// </summary>
-        /// <exception cref="NotImplementedException">To be implemented.</exception>
-        public virtual void DeleteBulk(IEnumerable<PK> ids)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{T})"/>
+        /// <see cref="IBulkRepository{T}.DeleteBulk(IEnumerable{T})"/>
         /// </summary>
         /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual void DeleteBulk(IEnumerable<T> objs)
@@ -371,16 +277,7 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{PK}, CancellationToken)"/>
-        /// </summary>
-        /// <exception cref="NotImplementedException">To be implemented.</exception>
-        public virtual Task DeleteBulkAsync(IEnumerable<PK> ids, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// <see cref="IBulkRepository{T}.DeleteBulkAsync(IEnumerable{T}, CancellationToken)"/>
         /// </summary>
         /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual Task DeleteBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
@@ -431,72 +328,6 @@ namespace Tardigrade.Framework.AzureStorage
         private async Task<bool> ExistsAsync(string partitionKey, string rowKey)
         {
             return ((await RetrieveAsync(partitionKey, rowKey)) != null);
-        }
-
-        /// <summary>
-        /// Get the table result for a retrieve operation based upon partition and row keys.
-        /// </summary>
-        /// <param name="partitionKey">Partition key.</param>
-        /// <param name="rowKey">Row key.</param>
-        /// <returns>Storage table result.</returns>
-        /// <exception cref="ArgumentNullException">The partitionKey and/or rowKey parameters are null or empty.</exception>
-        /// <exception cref="RepositoryException">Error getting the storage table result.</exception>
-        private TableResult GetRetrieveTableResult(string partitionKey, string rowKey)
-        {
-            if (string.IsNullOrWhiteSpace(partitionKey))
-            {
-                throw new ArgumentNullException("Unique identifier does not specify a Partition Key.", nameof(partitionKey));
-            }
-
-            if (string.IsNullOrWhiteSpace(rowKey))
-            {
-                throw new ArgumentNullException("Unique identifier does not specify a Row Key.", nameof(rowKey));
-            }
-
-            TableResult result;
-
-            // Create a retrieve operation that expects partition and row keys.
-            TableOperation retrieveOperation = TableOperation.Retrieve<T>(partitionKey, rowKey);
-
-            // Execute the operation.
-            try
-            {
-                result = table.ExecuteAsync(retrieveOperation).GetAwaiter().GetResult();
-            }
-            catch (Exception e)
-            {
-                throw new RepositoryException($"Error executing retrieve operation on object of type {typeof(T).Name} with Partition Key {partitionKey} and Row Key{rowKey} in Azure Storage Table {table.Name} .", e);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Get the table result for a retrieve operation based upon partition and row keys.
-        /// </summary>
-        /// <param name="partitionKey">Partition key.</param>
-        /// <param name="rowKey">Row key.</param>
-        /// <returns>Storage table result.</returns>
-        /// <exception cref="ArgumentNullException">The partitionKey and/or rowKey parameters are null or empty.</exception>
-        private async Task<TableResult> GetRetrieveTableResultAsync(string partitionKey, string rowKey)
-        {
-            if (string.IsNullOrWhiteSpace(partitionKey))
-            {
-                throw new ArgumentNullException("Unique identifier does not specify a Partition Key.", nameof(partitionKey));
-            }
-
-            if (string.IsNullOrWhiteSpace(rowKey))
-            {
-                throw new ArgumentNullException("Unique identifier does not specify a Row Key.", nameof(rowKey));
-            }
-
-            // Create a retrieve operation that expects partition and row keys.
-            TableOperation retrieveOperation = TableOperation.Retrieve<T>(partitionKey, rowKey);
-
-            // Execute the operation.
-            TableResult result = await table.ExecuteAsync(retrieveOperation);
-
-            return result;
         }
 
         /// <summary>
@@ -567,7 +398,30 @@ namespace Tardigrade.Framework.AzureStorage
         /// <exception cref="RepositoryException">Error retrieving the object.</exception>
         private T Retrieve(string partitionKey, string rowKey)
         {
-            TableResult result = GetRetrieveTableResult(partitionKey, rowKey);
+            if (string.IsNullOrWhiteSpace(partitionKey))
+            {
+                throw new ArgumentNullException("Unique identifier does not specify a Partition Key.", nameof(partitionKey));
+            }
+
+            if (string.IsNullOrWhiteSpace(rowKey))
+            {
+                throw new ArgumentNullException("Unique identifier does not specify a Row Key.", nameof(rowKey));
+            }
+
+            TableResult result;
+
+            // Create a retrieve operation that expects partition and row keys.
+            TableOperation retrieveOperation = TableOperation.Retrieve<T>(partitionKey, rowKey);
+
+            // Execute the operation.
+            try
+            {
+                result = table.ExecuteAsync(retrieveOperation).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                throw new RepositoryException($"Error executing retrieve operation on object of type {typeof(T).Name} with Partition Key {partitionKey} and Row Key{rowKey} in Azure Storage Table {table.Name} .", e);
+            }
 
             T obj;
 
@@ -652,7 +506,21 @@ namespace Tardigrade.Framework.AzureStorage
         /// <exception cref="RepositoryException">Error retrieving the object.</exception>
         private async Task<T> RetrieveAsync(string partitionKey, string rowKey)
         {
-            TableResult result = await GetRetrieveTableResultAsync(partitionKey, rowKey);
+            if (string.IsNullOrWhiteSpace(partitionKey))
+            {
+                throw new ArgumentNullException("Unique identifier does not specify a Partition Key.", nameof(partitionKey));
+            }
+
+            if (string.IsNullOrWhiteSpace(rowKey))
+            {
+                throw new ArgumentNullException("Unique identifier does not specify a Row Key.", nameof(rowKey));
+            }
+
+            // Create a retrieve operation that expects partition and row keys.
+            TableOperation retrieveOperation = TableOperation.Retrieve<T>(partitionKey, rowKey);
+
+            // Execute the operation.
+            TableResult result = await table.ExecuteAsync(retrieveOperation);
 
             T obj;
 
@@ -728,7 +596,7 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.UpdateBulk(IEnumerable{T})"/>
+        /// <see cref="IBulkRepository{T}.UpdateBulk(IEnumerable{T})"/>
         /// </summary>
         /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual void UpdateBulk(IEnumerable<T> objs)
@@ -737,7 +605,7 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.UpdateBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// <see cref="IBulkRepository{T}.UpdateBulkAsync(IEnumerable{T}, CancellationToken)"/>
         /// </summary>
         /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual Task UpdateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AzureStorage/StorageTableRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AzureStorage/StorageTableRepository.cs
@@ -77,7 +77,7 @@ namespace Tardigrade.Framework.AzureStorage
         /// <summary>
         /// <see cref="IRepository{T, PK}.Count(Expression{Func{T, bool}})"/>
         /// </summary>
-        /// <exception cref="NotImplementedException">Not currently implmented.</exception>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual int Count(Expression<Func<T, bool>> filter = null)
         {
             throw new NotImplementedException();
@@ -86,19 +86,10 @@ namespace Tardigrade.Framework.AzureStorage
         /// <summary>
         /// <see cref="IRepository{T, PK}.CountAsync(Expression{Func{T, bool}}, CancellationToken)"/>
         /// </summary>
-        /// <exception cref="NotImplementedException">Not currently implmented.</exception>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
         public virtual Task<int> CountAsync(
             Expression<Func<T, bool>> filter = null,
             CancellationToken cancellationToken = default(CancellationToken))
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.Create(IEnumerable{T})"/>
-        /// </summary>
-        /// <exception cref="NotImplementedException">Not currently implemented.</exception>
-        public virtual IEnumerable<T> Create(IEnumerable<T> objs)
         {
             throw new NotImplementedException();
         }
@@ -151,15 +142,6 @@ namespace Tardigrade.Framework.AzureStorage
         }
 
         /// <summary>
-        /// <see cref="IRepository{T, PK}.Create(IEnumerable{T})"/>
-        /// </summary>
-        /// <exception cref="NotImplementedException">Not currently implemented.</exception>
-        public virtual Task<IEnumerable<T>> CreateAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
         /// <see cref="IRepository{T, PK}.CreateAsync(T, CancellationToken)"/>
         /// </summary>
         /// <exception cref="ValidationException">Not supported.</exception>
@@ -202,6 +184,24 @@ namespace Tardigrade.Framework.AzureStorage
             }
 
             return obj;
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.CreateBulk(IEnumerable{T})"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual IEnumerable<T> CreateBulk(IEnumerable<T> objs)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.CreateBulk(IEnumerable{T})"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual Task<IEnumerable<T>> CreateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -350,6 +350,42 @@ namespace Tardigrade.Framework.AzureStorage
             {
                 throw new RepositoryException($"Delete failed; error code of {result.HttpStatusCode} was returned for object of type {typeof(T).Name} with Partition Key {obj.PartitionKey} and Row Key{obj.RowKey} in Azure Storage Table {table.Name}.");
             }
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{PK})"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual void DeleteBulk(IEnumerable<PK> ids)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{T})"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual void DeleteBulk(IEnumerable<T> objs)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{PK}, CancellationToken)"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual Task DeleteBulkAsync(IEnumerable<PK> ids, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual Task DeleteBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -689,6 +725,24 @@ namespace Tardigrade.Framework.AzureStorage
 
             // Execute the operation.
             await table.ExecuteAsync(insertOrReplaceOperation);
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.UpdateBulk(IEnumerable{T})"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual void UpdateBulk(IEnumerable<T> objs)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.UpdateBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual Task UpdateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AzureStorage/Tardigrade.Framework.AzureStorage.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AzureStorage/Tardigrade.Framework.AzureStorage.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>4.1.0</Version>
+    <Version>5.0.0</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library (Azure Storage Integration)</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework.Tests/Tardigrade.Framework.EntityFramework.Tests.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework.Tests/Tardigrade.Framework.EntityFramework.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework.Tests/UnitTest1.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework.Tests/UnitTest1.cs
@@ -1,0 +1,14 @@
+using System;
+using Xunit;
+
+namespace Tardigrade.Framework.EntityFramework.Tests
+{
+    public class UnitTest1
+    {
+        [Fact]
+        public void Test1()
+        {
+
+        }
+    }
+}

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/EntityFrameworkRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/EntityFrameworkRepository.cs
@@ -172,7 +172,7 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.CreateBulk(IEnumerable{T})"/>
+        /// <see cref="IBulkRepository{T}.CreateBulk(IEnumerable{T})"/>
         /// </summary>
         public virtual IEnumerable<T> CreateBulk(IEnumerable<T> objs)
         {
@@ -202,7 +202,7 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.CreateBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// <see cref="IBulkRepository{T}.CreateBulkAsync(IEnumerable{T}, CancellationToken)"/>
         /// </summary>
         public virtual async Task<IEnumerable<T>> CreateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
         {
@@ -223,49 +223,6 @@ namespace Tardigrade.Framework.EntityFramework
             }
 
             return objs;
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.Delete(PK)"/>
-        /// </summary>
-        public virtual void Delete(PK id)
-        {
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            T obj;
-
-            try
-            {
-                obj = GenerateFindQuery().Find(id);
-
-                if (obj == null)
-                {
-                    throw new NotFoundException($"Delete failed; object of type {typeof(T).Name} with primary key {id} does not exist.");
-                }
-            }
-            catch (InvalidOperationException e)
-            {
-                throw new RepositoryException($"Delete failed; database connection error while deleting object of type {typeof(T).Name} with primary key {id}.", e);
-            }
-
-            DbContext.Set<T>().Remove(obj);
-
-            try
-            {
-                DbContext.SaveChanges();
-            }
-            catch (Exception e) when (
-                e is DbUpdateException ||
-                e is DbUpdateConcurrencyException ||
-                e is NotSupportedException ||
-                e is ObjectDisposedException ||
-                e is InvalidOperationException)
-            {
-                throw new RepositoryException($"Delete failed; database error while deleting object of type {typeof(T).Name} with primary key {id}.", e);
-            }
         }
 
         /// <summary>
@@ -314,35 +271,6 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
-        /// <see cref="IRepository{T, PK}.DeleteAsync(PK, CancellationToken)"/>
-        /// </summary>
-        public virtual async Task DeleteAsync(PK id, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            T obj = await GenerateFindQuery().FindAsync(id, cancellationToken);
-
-            if (obj == null)
-            {
-                throw new NotFoundException($"Delete failed; object of type {typeof(T).Name} with primary key {id} does not exist.");
-            }
-
-            DbContext.Set<T>().Remove(obj);
-
-            try
-            {
-                await DbContext.SaveChangesAsync(cancellationToken);
-            }
-            catch (InvalidOperationException e)
-            {
-                throw new RepositoryException($"Delete failed; database connection error while deleting object of type {typeof(T).Name} with primary key {id}.", e);
-            }
-        }
-
-        /// <summary>
         /// <see cref="IRepository{T, PK}.DeleteAsync(T, CancellationToken)"/>
         /// </summary>
         public virtual async Task DeleteAsync(T obj, CancellationToken cancellationToken = default(CancellationToken))
@@ -382,16 +310,7 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{PK})"/>
-        /// </summary>
-        /// <exception cref="NotImplementedException">To be implemented.</exception>
-        public virtual void DeleteBulk(IEnumerable<PK> ids)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{T})"/>
+        /// <see cref="IBulkRepository{T}.DeleteBulk(IEnumerable{T})"/>
         /// </summary>
         public virtual void DeleteBulk(IEnumerable<T> objs)
         {
@@ -419,16 +338,7 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{PK}, CancellationToken)"/>
-        /// </summary>
-        /// <exception cref="NotImplementedException">To be implemented.</exception>
-        public virtual Task DeleteBulkAsync(IEnumerable<PK> ids, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// <see cref="IBulkRepository{T}.DeleteBulkAsync(IEnumerable{T}, CancellationToken)"/>
         /// </summary>
         public virtual async Task DeleteBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
         {
@@ -514,7 +424,7 @@ namespace Tardigrade.Framework.EntityFramework
         /// </summary>
         /// <param name="includes">A list of related objects to include in the query results.</param>
         /// <returns>Query to retrieve a set of objects.</returns>
-        private DbSet<T> GenerateFindQuery(params Expression<Func<T, object>>[] includes)
+        private DbSet<T> FindQuery(params Expression<Func<T, object>>[] includes)
         {
             DbSet<T> query = DbContext.Set<T>();
 
@@ -527,6 +437,67 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
+        /// <see cref="IRepository{T, PK}.Retrieve(Expression{Func{T, bool}}, PagingContext, Func{IQueryable{T}, IOrderedQueryable{T}}, Expression{Func{T, object}}[])"/>
+        /// </summary>
+        public virtual IEnumerable<T> Retrieve(
+            Expression<Func<T, bool>> filter = null,
+            PagingContext pagingContext = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> sortCondition = null,
+            params Expression<Func<T, object>>[] includes)
+        {
+            return RetrieveQuery(filter, pagingContext, sortCondition, includes).ToList();
+        }
+
+        /// <summary>
+        /// <see cref="IRepository{T, PK}.Retrieve(PK, Expression{Func{T, object}}[])"/>
+        /// </summary>
+        public virtual T Retrieve(PK id, params Expression<Func<T, object>>[] includes)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            try
+            {
+                return FindQuery(includes).Find(id);
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new RepositoryException($"Retrieve failed; database connection error while retrieving object of type {typeof(T).Name} with primary key {id}.", e);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="IRepository{T, PK}.RetrieveAsync(Expression{Func{T, bool}}, PagingContext, Func{IQueryable{T}, IOrderedQueryable{T}}, CancellationToken, Expression{Func{T, object}}[])"/>
+        /// </summary>
+        public virtual async Task<IEnumerable<T>> RetrieveAsync(
+            Expression<Func<T, bool>> filter = null,
+            PagingContext pagingContext = null,
+            Func<IQueryable<T>, IOrderedQueryable<T>> sortCondition = null,
+            CancellationToken cancellationToken = default(CancellationToken),
+            params Expression<Func<T, object>>[] includes)
+        {
+            return await RetrieveQuery(filter, pagingContext, sortCondition, includes).ToListAsync(cancellationToken);
+        }
+
+        /// <summary>
+        /// <see cref="IRepository{T, PK}.RetrieveAsync(PK, CancellationToken, Expression{Func{T, object}}[])"/>
+        /// </summary>
+        public virtual async Task<T> RetrieveAsync(
+            PK id,
+            CancellationToken cancellationToken = default(CancellationToken),
+            params Expression<Func<T, object>>[] includes)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            return await FindQuery(includes).FindAsync(id, cancellationToken);
+        }
+
+        /// <summary>
         /// Generate a query to retrieve all instances of the object type.
         /// </summary>
         /// <param name="filter">Filter condition.</param>
@@ -535,7 +506,7 @@ namespace Tardigrade.Framework.EntityFramework
         /// <param name="includes">A list of related objects to include in the query results.</param>
         /// <returns>Query to retrieve all instances of the object type.</returns>
         /// <exception cref="ArgumentException">A sortCondition is required if pagingContext is provided.</exception>"
-        private IQueryable<T> GenerateRetrieveQuery(
+        private IQueryable<T> RetrieveQuery(
             Expression<Func<T, bool>> filter = null,
             PagingContext pagingContext = null,
             Func<IQueryable<T>, IOrderedQueryable<T>> sortCondition = null,
@@ -576,67 +547,6 @@ namespace Tardigrade.Framework.EntityFramework
             }
 
             return query;
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.Retrieve(Expression{Func{T, bool}}, PagingContext, Func{IQueryable{T}, IOrderedQueryable{T}}, Expression{Func{T, object}}[])"/>
-        /// </summary>
-        public virtual IEnumerable<T> Retrieve(
-            Expression<Func<T, bool>> filter = null,
-            PagingContext pagingContext = null,
-            Func<IQueryable<T>, IOrderedQueryable<T>> sortCondition = null,
-            params Expression<Func<T, object>>[] includes)
-        {
-            return GenerateRetrieveQuery(filter, pagingContext, sortCondition, includes).ToList();
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.Retrieve(PK, Expression{Func{T, object}}[])"/>
-        /// </summary>
-        public virtual T Retrieve(PK id, params Expression<Func<T, object>>[] includes)
-        {
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            try
-            {
-                return GenerateFindQuery(includes).Find(id);
-            }
-            catch (InvalidOperationException e)
-            {
-                throw new RepositoryException($"Retrieve failed; database connection error while retrieving object of type {typeof(T).Name} with primary key {id}.", e);
-            }
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.RetrieveAsync(Expression{Func{T, bool}}, PagingContext, Func{IQueryable{T}, IOrderedQueryable{T}}, CancellationToken, Expression{Func{T, object}}[])"/>
-        /// </summary>
-        public virtual async Task<IEnumerable<T>> RetrieveAsync(
-            Expression<Func<T, bool>> filter = null,
-            PagingContext pagingContext = null,
-            Func<IQueryable<T>, IOrderedQueryable<T>> sortCondition = null,
-            CancellationToken cancellationToken = default(CancellationToken),
-            params Expression<Func<T, object>>[] includes)
-        {
-            return await GenerateRetrieveQuery(filter, pagingContext, sortCondition, includes).ToListAsync(cancellationToken);
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.RetrieveAsync(PK, CancellationToken, Expression{Func{T, object}}[])"/>
-        /// </summary>
-        public virtual async Task<T> RetrieveAsync(
-            PK id,
-            CancellationToken cancellationToken = default(CancellationToken),
-            params Expression<Func<T, object>>[] includes)
-        {
-            if (id == null)
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            return await GenerateFindQuery(includes).FindAsync(id, cancellationToken);
         }
 
         /// <summary>
@@ -719,7 +629,7 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.UpdateBulk(IEnumerable{T})"/>
+        /// <see cref="IBulkRepository{T}.UpdateBulk(IEnumerable{T})"/>
         /// </summary>
         public virtual void UpdateBulk(IEnumerable<T> objs)
         {
@@ -757,7 +667,7 @@ namespace Tardigrade.Framework.EntityFramework
         }
 
         /// <summary>
-        /// <see cref="IBulkRepository{T, PK}.UpdateBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// <see cref="IBulkRepository{T}.UpdateBulkAsync(IEnumerable{T}, CancellationToken)"/>
         /// </summary>
         public virtual async Task UpdateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
         {

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/EntityFrameworkRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/EntityFrameworkRepository.cs
@@ -452,6 +452,8 @@ namespace Tardigrade.Framework.EntityFramework
         /// <summary>
         /// <see cref="IRepository{T, PK}.Retrieve(PK, Expression{Func{T, object}}[])"/>
         /// <a href="https://stackoverflow.com/questions/39434878/how-to-include-related-tables-in-dbset-find">How to include related tables in DbSet.Find()?</a>
+        /// <a href="https://docs.microsoft.com/en-au/ef/ef6/querying/related-data">Loading Related Entities</a>
+        /// <a href="https://devblogs.microsoft.com/csharpfaq/how-can-i-get-objects-and-property-values-from-expression-trees/">How can I get objects and property values from expression trees?</a>
         /// </summary>
         public virtual T Retrieve(PK id, params Expression<Func<T, object>>[] includes)
         {
@@ -511,6 +513,8 @@ namespace Tardigrade.Framework.EntityFramework
         /// <summary>
         /// <see cref="IRepository{T, PK}.RetrieveAsync(PK, CancellationToken, Expression{Func{T, object}}[])"/>
         /// <a href="https://stackoverflow.com/questions/39434878/how-to-include-related-tables-in-dbset-find">How to include related tables in DbSet.Find()?</a>
+        /// <a href="https://docs.microsoft.com/en-au/ef/ef6/querying/related-data">Loading Related Entities</a>
+        /// <a href="https://devblogs.microsoft.com/csharpfaq/how-can-i-get-objects-and-property-values-from-expression-trees/">How can I get objects and property values from expression trees?</a>
         /// </summary>
         public virtual async Task<T> RetrieveAsync(
             PK id,

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/Properties/AssemblyInfo.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.0.0")]
-[assembly: AssemblyFileVersion("6.0.0.0")]
+[assembly: AssemblyVersion("7.0.0.0")]
+[assembly: AssemblyFileVersion("7.0.0.0")]

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/Tardigrade.Framework.EntityFramework.nuspec
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/Tardigrade.Framework.EntityFramework.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Tardigrade.Framework.EntityFramework</id>
-    <version>6.0.0</version>
+    <version>7.0.0</version>
     <title>Tardigrade Framework Library (Entity Framework Integration)</title>
     <authors>Rafidzal Rafiq</authors>
     <owners>Rafidzal Rafiq</owners>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFrameworkCore/EntityFrameworkCoreRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFrameworkCore/EntityFrameworkCoreRepository.cs
@@ -88,21 +88,6 @@ namespace Tardigrade.Framework.EntityFrameworkCore
         }
 
         /// <summary>
-        /// <see cref="IRepository{T, PK}.Create(IEnumerable{T})"/>
-        /// </summary>
-        public virtual IEnumerable<T> Create(IEnumerable<T> objs)
-        {
-            if (objs.IsNulOrEmpty())
-            {
-                throw new ArgumentNullException(nameof(objs));
-            }
-
-            DbContext.BulkInsert((IList<T>)objs);
-
-            return objs;
-        }
-
-        /// <summary>
         /// <see cref="IRepository{T, PK}.Create(T)"/>
         /// </summary>
         /// <exception cref="ValidationException">Not supported.</exception>
@@ -130,23 +115,6 @@ namespace Tardigrade.Framework.EntityFrameworkCore
             }
 
             return obj;
-        }
-
-        /// <summary>
-        /// <see cref="IRepository{T, PK}.CreateAsync(IEnumerable{T}, CancellationToken)"/>
-        /// </summary>
-        /// <param name="objs">Instances to create.</param>
-        /// <param name="cancellationToken">Not supported.</param>
-        public virtual async Task<IEnumerable<T>> CreateAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
-        {
-            if (objs.IsNulOrEmpty())
-            {
-                throw new ArgumentNullException(nameof(objs));
-            }
-
-            await DbContext.BulkInsertAsync((IList<T>)objs);
-
-            return objs;
         }
 
         /// <summary>
@@ -181,6 +149,38 @@ namespace Tardigrade.Framework.EntityFrameworkCore
             }
 
             return obj;
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.CreateBulk(IEnumerable{T})"/>
+        /// </summary>
+        public virtual IEnumerable<T> CreateBulk(IEnumerable<T> objs)
+        {
+            if (objs.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(objs));
+            }
+
+            DbContext.BulkInsert((IList<T>)objs);
+
+            return objs;
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.CreateBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// </summary>
+        /// <param name="objs">Instances to create.</param>
+        /// <param name="cancellationToken">Not supported.</param>
+        public virtual async Task<IEnumerable<T>> CreateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
+        {
+            if (objs.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(objs));
+            }
+
+            await DbContext.BulkInsertAsync((IList<T>)objs);
+
+            return objs;
         }
 
         /// <summary>
@@ -303,6 +303,63 @@ namespace Tardigrade.Framework.EntityFrameworkCore
             {
                 throw new RepositoryException($"Delete failed; database error while deleting object of type {typeof(T).Name} with primary key {obj.Id}.", e);
             }
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{PK})"/>
+        /// </summary>
+        public virtual void DeleteBulk(IEnumerable<PK> ids)
+        {
+            if (ids.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
+            IList<T> objs = DbContext.Set<T>().Where(o => ids.Contains(o.Id)).ToList();
+            DbContext.BulkDelete(objs);
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulk(IEnumerable{T})"/>
+        /// </summary>
+        public virtual void DeleteBulk(IEnumerable<T> objs)
+        {
+            if (objs.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(objs));
+            }
+
+            DbContext.BulkDelete((IList<T>)objs);
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{PK}, CancellationToken)"/>
+        /// </summary>
+        /// <exception cref="NotImplementedException">To be implemented.</exception>
+        public virtual async Task DeleteBulkAsync(IEnumerable<PK> ids, CancellationToken cancellationToken = default)
+        {
+            if (ids.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(ids));
+            }
+
+            IList<T> objs = await DbContext.Set<T>().Where(o => ids.Contains(o.Id)).ToListAsync();
+            await DbContext.BulkDeleteAsync(objs);
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.DeleteBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// </summary>
+        /// <param name="objs">Instances to delete.</param>
+        /// <param name="cancellationToken">Not supported.</param>
+        public virtual async Task DeleteBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
+        {
+            if (objs.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(objs));
+            }
+
+            await DbContext.BulkDeleteAsync((IList<T>)objs);
         }
 
         /// <summary>
@@ -510,6 +567,34 @@ namespace Tardigrade.Framework.EntityFrameworkCore
             {
                 throw new RepositoryException($"Update failed; database error while updating object of type {typeof(T).Name} with primary key {obj.Id}.", e);
             }
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.UpdateBulk(IEnumerable{T})"/>
+        /// </summary>
+        public virtual void UpdateBulk(IEnumerable<T> objs)
+        {
+            if (objs.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(objs));
+            }
+
+            DbContext.BulkUpdate((IList<T>)objs);
+        }
+
+        /// <summary>
+        /// <see cref="IBulkRepository{T, PK}.UpdateBulkAsync(IEnumerable{T}, CancellationToken)"/>
+        /// </summary>
+        /// <param name="objs">Instances to update.</param>
+        /// <param name="cancellationToken">Not supported.</param>
+        public virtual async Task UpdateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default)
+        {
+            if (objs.IsNulOrEmpty())
+            {
+                throw new ArgumentNullException(nameof(objs));
+            }
+
+            await DbContext.BulkUpdateAsync((IList<T>)objs);
         }
     }
 }

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFrameworkCore/Tardigrade.Framework.EntityFrameworkCore.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFrameworkCore/Tardigrade.Framework.EntityFrameworkCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <Version>6.0.0</Version>
+    <Version>7.0.0</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library (Entity Framework Core Integration)</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.sln
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tardigrade.Framework.AspNet
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tardigrade.Framework.EntityFramework", "Tardigrade.Framework.EntityFramework\Tardigrade.Framework.EntityFramework.csproj", "{43161900-684A-493A-90E4-0B46A4F9684F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tardigrade.Framework.EntityFramework.Tests", "Tardigrade.Framework.EntityFramework.Tests\Tardigrade.Framework.EntityFramework.Tests.csproj", "{661A6ED5-C114-4AA5-BC3A-37A298C192B9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{43161900-684A-493A-90E4-0B46A4F9684F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43161900-684A-493A-90E4-0B46A4F9684F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43161900-684A-493A-90E4-0B46A4F9684F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{661A6ED5-C114-4AA5-BC3A-37A298C192B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{661A6ED5-C114-4AA5-BC3A-37A298C192B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{661A6ED5-C114-4AA5-BC3A-37A298C192B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{661A6ED5-C114-4AA5-BC3A-37A298C192B9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Helpers/AsyncHelper.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Helpers/AsyncHelper.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation, Inc. All rights reserved.
+// Licensed under the MIT License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tardigrade.Framework.Helpers
+{
+    /// <summary>
+    /// Helper class to run asynchronous methods within a synchronous process.
+    /// <a href="https://cpratt.co/async-tips-tricks/">C# Async Tips &amp; Tricks</a>
+    /// <a href="https://www.ryadel.com/en/asyncutil-c-helper-class-async-method-sync-result-wait/">AsyncUtil – C# Helper class to run async methods as sync and vice-versa</a>
+    /// <a href="https://github.com/aspnet/AspNetIdentity/blob/master/src/Microsoft.AspNet.Identity.Core/AsyncHelper.cs">AsyncHelper.cs</a>
+    /// <a href="https://stackoverflow.com/questions/9343594/how-to-call-asynchronous-method-from-synchronous-method-in-c">How to call asynchronous method from synchronous method in C#?</a>
+    /// </summary>
+    public static class AsyncHelper
+    {
+        private static readonly TaskFactory taskFactory = new TaskFactory(
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            TaskContinuationOptions.None,
+            TaskScheduler.Default);
+
+        /// <summary>
+        /// Execute an asynchronous method which returns void synchronously.
+        /// Usage: AsyncHelper.RunSync(() => asyncMethod());
+        /// </summary>
+        /// <param name="func">Asynchronous method to execute.</param>
+        public static void RunSync(Func<Task> func)
+        {
+            CultureInfo culture = CultureInfo.CurrentCulture;
+            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
+
+            taskFactory
+                .StartNew(() =>
+                {
+                    Thread.CurrentThread.CurrentCulture = culture;
+                    Thread.CurrentThread.CurrentUICulture = uiCulture;
+                    return func();
+                })
+                .Unwrap()
+                .GetAwaiter()
+                .GetResult();
+        }
+
+        /// <summary>
+        /// Execute an asynchronous method which has a return type synchronously.
+        /// Usage: T result = AsyncHelper.RunSync(() => asyncMethod{T}());
+        /// </summary>
+        /// <typeparam name="T">Return type.</typeparam>
+        /// <param name="func">Asynchronous method to execute.</param>
+        /// <returns>Result of the method execution.</returns>
+        public static T RunSync<T>(Func<Task<T>> func)
+        {
+            CultureInfo culture = CultureInfo.CurrentCulture;
+            CultureInfo uiCulture = CultureInfo.CurrentUICulture;
+
+            return taskFactory
+                .StartNew(() =>
+                {
+                    Thread.CurrentThread.CurrentCulture = culture;
+                    Thread.CurrentThread.CurrentUICulture = uiCulture;
+                    return func();
+                })
+                .Unwrap()
+                .GetAwaiter()
+                .GetResult();
+        }
+    }
+}

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IBatchRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IBatchRepository.cs
@@ -1,0 +1,12 @@
+﻿namespace Tardigrade.Framework.Persistence
+{
+    /// <summary>
+    /// Base repository interface of batch operations on objects of a particular type. Batch operations process a
+    /// collection of objects individually, and success or failure applies to each individual object in the collection.
+    /// </summary>
+    /// <typeparam name="T">Object type associated with the repository operations.</typeparam>
+    /// <typeparam name="PK">Unique identifier type for the object type.</typeparam>
+    public interface IBatchRepository<T, PK>
+    {
+    }
+}

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IBulkRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IBulkRepository.cs
@@ -10,8 +10,7 @@ namespace Tardigrade.Framework.Persistence
     /// collection of objects at once, and success or failure applies to the collection as a whole.
     /// </summary>
     /// <typeparam name="T">Object type associated with the repository operations.</typeparam>
-    /// <typeparam name="PK">Unique identifier type for the object type.</typeparam>
-    public interface IBulkRepository<T, PK>
+    public interface IBulkRepository<T>
     {
         /// <summary>
         /// Create multiple instances of the object type.
@@ -35,30 +34,12 @@ namespace Tardigrade.Framework.Persistence
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete multiple instances by unique identifier.
-        /// </summary>
-        /// <param name="ids">Collection of unique identifiers.</param>
-        /// <exception cref="ArgumentNullException">The ids parameter is null or empty.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error deleting the objects.</exception>
-        void DeleteBulk(IEnumerable<PK> ids);
-
-        /// <summary>
         /// Delete multiple instances.
         /// </summary>
         /// <param name="objs">Instances to delete.</param>
         /// <exception cref="ArgumentNullException">The objs parameter is null or empty.</exception>
         /// <exception cref="Exceptions.RepositoryException">Error deleting the objects.</exception>
         void DeleteBulk(IEnumerable<T> objs);
-
-        /// <summary>
-        /// Delete multiple instances by unique identifier.
-        /// </summary>
-        /// <param name="ids">Collection of unique identifiers.</param>
-        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
-        /// <returns>Task object representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">The ids parameter is null or empty.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error deleting the objects.</exception>
-        Task DeleteBulkAsync(IEnumerable<PK> ids, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Delete multiple instances.

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IBulkRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IBulkRepository.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Tardigrade.Framework.Persistence
+{
+    /// <summary>
+    /// Base repository interface of bulk operations on objects of a particular type. Bulk operations process a
+    /// collection of objects at once, and success or failure applies to the collection as a whole.
+    /// </summary>
+    /// <typeparam name="T">Object type associated with the repository operations.</typeparam>
+    /// <typeparam name="PK">Unique identifier type for the object type.</typeparam>
+    public interface IBulkRepository<T, PK>
+    {
+        /// <summary>
+        /// Create multiple instances of the object type.
+        /// </summary>
+        /// <param name="objs">Instances to create.</param>
+        /// <returns>Instances created (including allocated unique identifiers).</returns>
+        /// <exception cref="ArgumentNullException">The objs parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error creating the objects.</exception>
+        IEnumerable<T> CreateBulk(IEnumerable<T> objs);
+
+        /// <summary>
+        /// Create multiple instances of the object type.
+        /// </summary>
+        /// <param name="objs">Instances to create.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+        /// <returns>Instances created (including allocated unique identifiers).</returns>
+        /// <exception cref="ArgumentNullException">The objs parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error creating the objects.</exception>
+        Task<IEnumerable<T>> CreateBulkAsync(
+            IEnumerable<T> objs,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Delete multiple instances by unique identifier.
+        /// </summary>
+        /// <param name="ids">Collection of unique identifiers.</param>
+        /// <exception cref="ArgumentNullException">The ids parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error deleting the objects.</exception>
+        void DeleteBulk(IEnumerable<PK> ids);
+
+        /// <summary>
+        /// Delete multiple instances.
+        /// </summary>
+        /// <param name="objs">Instances to delete.</param>
+        /// <exception cref="ArgumentNullException">The objs parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error deleting the objects.</exception>
+        void DeleteBulk(IEnumerable<T> objs);
+
+        /// <summary>
+        /// Delete multiple instances by unique identifier.
+        /// </summary>
+        /// <param name="ids">Collection of unique identifiers.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+        /// <returns>Task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException">The ids parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error deleting the objects.</exception>
+        Task DeleteBulkAsync(IEnumerable<PK> ids, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Delete multiple instances.
+        /// </summary>
+        /// <param name="objs">Instances to delete.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+        /// <returns>Task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException">The objs parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error deleting the objects.</exception>
+        Task DeleteBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Update multiple instances.
+        /// </summary>
+        /// <param name="objs">Instances to update.</param>
+        /// <exception cref="ArgumentNullException">The objs parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error updating the objects.</exception>
+        void UpdateBulk(IEnumerable<T> objs);
+
+        /// <summary>
+        /// Update multiple instances.
+        /// </summary>
+        /// <param name="objs">Instances to update.</param>
+        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+        /// <returns>Task object representing the asynchronous operation.</returns>
+        /// <exception cref="ArgumentNullException">The objs parameter is null or empty.</exception>
+        /// <exception cref="Exceptions.RepositoryException">Error updating the objects.</exception>
+        Task UpdateBulkAsync(IEnumerable<T> objs, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IRepository.cs
@@ -15,7 +15,7 @@ namespace Tardigrade.Framework.Persistence
     /// </summary>
     /// <typeparam name="T">Object type associated with the repository operations.</typeparam>
     /// <typeparam name="PK">Unique identifier type for the object type.</typeparam>
-    public interface IRepository<T, PK> : IBulkRepository<T, PK>
+    public interface IRepository<T, PK> : IBulkRepository<T>
     {
         /// <summary>
         /// Calculate the number of objects in the repository.
@@ -60,15 +60,6 @@ namespace Tardigrade.Framework.Persistence
         Task<T> CreateAsync(T obj, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete an instance by unique identifier.
-        /// </summary>
-        /// <param name="id">Unique identifier for the instance.</param>
-        /// <exception cref="ArgumentNullException">The id parameter is null.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Object to delete does not exist.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error deleting the object.</exception>
-        void Delete(PK id);
-
-        /// <summary>
         /// Delete an instance.
         /// </summary>
         /// <param name="obj">Instance to delete.</param>
@@ -76,17 +67,6 @@ namespace Tardigrade.Framework.Persistence
         /// <exception cref="Exceptions.NotFoundException">Object to delete does not exist.</exception>
         /// <exception cref="Exceptions.RepositoryException">Error deleting the object.</exception>
         void Delete(T obj);
-
-        /// <summary>
-        /// Delete an instance by unique identifier.
-        /// </summary>
-        /// <param name="id">Unique identifier for the instance.</param>
-        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
-        /// <returns>Task object representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">The id parameter is null.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Object to delete does not exist.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error deleting the object.</exception>
-        Task DeleteAsync(PK id, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Delete an instance.

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IRepository.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Persistence/IRepository.cs
@@ -15,7 +15,7 @@ namespace Tardigrade.Framework.Persistence
     /// </summary>
     /// <typeparam name="T">Object type associated with the repository operations.</typeparam>
     /// <typeparam name="PK">Unique identifier type for the object type.</typeparam>
-    public interface IRepository<T, PK>
+    public interface IRepository<T, PK> : IBulkRepository<T, PK>
     {
         /// <summary>
         /// Calculate the number of objects in the repository.
@@ -37,15 +37,6 @@ namespace Tardigrade.Framework.Persistence
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Create multiple instances of the object type.
-        /// </summary>
-        /// <param name="objs">Instances to create.</param>
-        /// <returns>Instances created (including allocated unique identifiers).</returns>
-        /// <exception cref="ArgumentNullException">The objs parameter is null.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error creating the objects.</exception>
-        IEnumerable<T> Create(IEnumerable<T> objs);
-
-        /// <summary>
         /// Create an instance of the object type.
         /// </summary>
         /// <param name="obj">Instance to create.</param>
@@ -55,18 +46,6 @@ namespace Tardigrade.Framework.Persistence
         /// <exception cref="Exceptions.RepositoryException">Error creating the object.</exception>
         /// <exception cref="Exceptions.ValidationException">Object to create contains invalid values.</exception>
         T Create(T obj);
-
-        /// <summary>
-        /// Create multiple instances of the object type.
-        /// </summary>
-        /// <param name="objs">Instances to create.</param>
-        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
-        /// <returns>Instances created (including allocated unique identifiers).</returns>
-        /// <exception cref="ArgumentNullException">The objs parameter is null.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error creating the objects.</exception>
-        Task<IEnumerable<T>> CreateAsync(
-            IEnumerable<T> objs,
-            CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Create an instance of the object type.

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Services/DtoService.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Services/DtoService.cs
@@ -197,54 +197,12 @@ namespace Tardigrade.Framework.Services
         }
 
         /// <summary>
-        /// <see cref="IObjectService{Dto, DtoPk}.Delete(DtoPk)"/>
-        /// </summary>
-        public virtual void Delete(DtoPk id)
-        {
-            try
-            {
-                if (KeyEncoder != null)
-                {
-                    id = KeyEncoder.Decode(id);
-                }
-
-                ModelPk modelId = Mapper.Map<ModelPk>(id);
-                ObjectService.Delete(modelId);
-            }
-            catch (EncodingException e)
-            {
-                throw new ServiceException($"Error deleting an object of type {typeof(Dto).Name} with a unique identifier of {id}.", e);
-            }
-        }
-
-        /// <summary>
         /// <see cref="IObjectService{Dto, DtoPk}.DeleteAsync(Dto, CancellationToken)"/>
         /// </summary>
         public virtual async Task DeleteAsync(Dto dto, CancellationToken cancellationToken = default)
         {
             Model model = Mapper.Map<Model>(dto);
             await ObjectService.DeleteAsync(model);
-        }
-
-        /// <summary>
-        /// <see cref="IObjectService{Dto, DtoPk}.DeleteAsync(DtoPk, CancellationToken)"/>
-        /// </summary>
-        public virtual async Task DeleteAsync(DtoPk id, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                if (KeyEncoder != null)
-                {
-                    id = KeyEncoder.Decode(id);
-                }
-
-                ModelPk modelId = Mapper.Map<ModelPk>(id);
-                await ObjectService.DeleteAsync(modelId);
-            }
-            catch (EncodingException e)
-            {
-                throw new ServiceException($"Error deleting an object of type {typeof(Dto).Name} with a unique identifier of {id}.", e);
-            }
         }
 
         /// <summary>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Services/IObjectService.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Services/IObjectService.cs
@@ -40,7 +40,7 @@ namespace Tardigrade.Framework.Services
         /// <param name="objs">Instances to create.</param>
         /// <returns>Instances created (including allocated unique identifiers).</returns>
         /// <exception cref="ArgumentNullException">The objs parameter is null.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error creating the objects.</exception>
+        /// <exception cref="Exceptions.ServiceException">Error creating the objects.</exception>
         IEnumerable<T> Create(IEnumerable<T> objs);
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Tardigrade.Framework.Services
         /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
         /// <returns>Instances created (including allocated unique identifiers).</returns>
         /// <exception cref="ArgumentNullException">The objs parameter is null.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error creating the objects.</exception>
+        /// <exception cref="Exceptions.ServiceException">Error creating the objects.</exception>
         Task<IEnumerable<T>> CreateAsync(
             IEnumerable<T> objs,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -77,14 +77,6 @@ namespace Tardigrade.Framework.Services
         Task<T> CreateAsync(T obj, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete an instance by unique identifier.
-        /// </summary>
-        /// <param name="id">Unique identifier for the instance.</param>
-        /// <exception cref="ArgumentNullException">The id parameter is null.</exception>
-        /// <exception cref="Exceptions.ServiceException">Error deleting the object.</exception>
-        void Delete(PK id);
-
-        /// <summary>
         /// Delete an instance.
         /// </summary>
         /// <param name="obj">Instance to delete.</param>
@@ -93,17 +85,6 @@ namespace Tardigrade.Framework.Services
         void Delete(T obj);
 
         /// <summary>
-        /// Delete an instance by unique identifier.
-        /// </summary>
-        /// <param name="id">Unique identifier for the instance.</param>
-        /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
-        /// <returns>Task object representing the asynchronous operation.</returns>
-        /// <exception cref="ArgumentNullException">The id parameter is null.</exception>
-        /// <exception cref="Exceptions.NotFoundException">Object to delete does not exist.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error deleting the object.</exception>
-        Task DeleteAsync(PK id, CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
         /// Delete an instance.
         /// </summary>
         /// <param name="obj">Instance to delete.</param>
@@ -111,7 +92,7 @@ namespace Tardigrade.Framework.Services
         /// <returns>Task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The obj parameter is null.</exception>
         /// <exception cref="Exceptions.NotFoundException">Object to delete does not exist.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error deleting the object.</exception>
+        /// <exception cref="Exceptions.ServiceException">Error deleting the object.</exception>
         Task DeleteAsync(T obj, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -130,7 +111,7 @@ namespace Tardigrade.Framework.Services
         /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
         /// <returns>True if the instance exists; false otherwise.</returns>
         /// <exception cref="ArgumentNullException">The id parameter is null.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error checking for existence of an object.</exception>
+        /// <exception cref="Exceptions.ServiceException">Error checking for existence of an object.</exception>
         Task<bool> ExistsAsync(PK id, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -171,7 +152,7 @@ namespace Tardigrade.Framework.Services
         /// <param name="includes">A list of related objects to include in the query results.</param>
         /// <returns>All instances if any; empty collection otherwise.</returns>
         /// <exception cref="ArgumentException">A sortCondition is required if pagingContext is provided.</exception>"
-        /// <exception cref="Exceptions.RepositoryException">Error retrieving the objects.</exception>
+        /// <exception cref="Exceptions.ServiceException">Error retrieving the objects.</exception>
         Task<IEnumerable<T>> RetrieveAsync(
             Expression<Func<T, bool>> filter = null,
             PagingContext pagingContext = null,
@@ -187,7 +168,7 @@ namespace Tardigrade.Framework.Services
         /// <param name="includes">A list of related objects to include in the query results.</param>
         /// <returns>Instance if found; null otherwise.</returns>
         /// <exception cref="ArgumentNullException">The id parameter is null.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error retrieving the object.</exception>
+        /// <exception cref="Exceptions.ServiceException">Error retrieving the object.</exception>
         Task<T> RetrieveAsync(
             PK id,
             CancellationToken cancellationToken = default(CancellationToken),
@@ -211,7 +192,7 @@ namespace Tardigrade.Framework.Services
         /// <returns>Task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The obj parameter is null.</exception>
         /// <exception cref="Exceptions.NotFoundException">Object to update does not exist.</exception>
-        /// <exception cref="Exceptions.RepositoryException">Error updating the object.</exception>
+        /// <exception cref="Exceptions.ServiceException">Error updating the object.</exception>
         /// <exception cref="Exceptions.ValidationException">Object to update contains invalid values.</exception>
         Task UpdateAsync(T obj, CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Services/ObjectService.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Services/ObjectService.cs
@@ -67,7 +67,7 @@ namespace Tardigrade.Framework.Services
         {
             try
             {
-                return Repository.Create(objs);
+                return Repository.CreateBulk(objs);
             }
             catch (RepositoryException e)
             {
@@ -99,7 +99,7 @@ namespace Tardigrade.Framework.Services
         {
             try
             {
-                return await Repository.CreateAsync(objs, cancellationToken);
+                return await Repository.CreateBulkAsync(objs, cancellationToken);
             }
             catch (RepositoryException e)
             {

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Services/ObjectService.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Services/ObjectService.cs
@@ -123,21 +123,6 @@ namespace Tardigrade.Framework.Services
         }
 
         /// <summary>
-        /// <see cref="IObjectService{T, PK}.Delete(PK)"/>
-        /// </summary>
-        public virtual void Delete(PK id)
-        {
-            try
-            {
-                Repository.Delete(id);
-            }
-            catch (RepositoryException e)
-            {
-                throw new ServiceException($"Error deleting an object of type {typeof(T).Name} with a unique identifier of {id}.", e);
-            }
-        }
-
-        /// <summary>
         /// <see cref="IObjectService{T, PK}.Delete(T)"/>
         /// </summary>
         public virtual void Delete(T obj)
@@ -149,21 +134,6 @@ namespace Tardigrade.Framework.Services
             catch (RepositoryException e)
             {
                 throw new ServiceException($"Error deleting an object of type {typeof(T).Name}.", e);
-            }
-        }
-
-        /// <summary>
-        /// <see cref="IObjectService{T, PK}.DeleteAsync(PK, CancellationToken)"/>
-        /// </summary>
-        public virtual async Task DeleteAsync(PK id, CancellationToken cancellationToken = default)
-        {
-            try
-            {
-                await Repository.DeleteAsync(id, cancellationToken);
-            }
-            catch (RepositoryException e)
-            {
-                throw new ServiceException($"Error deleting an object of type {typeof(T).Name} with a unique identifier of {id}.", e);
             }
         }
 

--- a/Code/Tardigrade.Framework/Tardigrade.Framework/Tardigrade.Framework.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework/Tardigrade.Framework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>7.0.0</Version>
+    <Version>8.0.0</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Framework for supporting coding best practices.
 
 ## Version control history
 
+**July 26, 2019 - 8.0.0 Redesigned the repository layer to better manage bulk operations**
+
+- Enhanced the repository layer to support bulk operations on delete and update.
+- Removed operations that delete objects by unique identifier from the repository and service layers.
+- Resolved issue regarding the use of "includes" with the DbSet<T>.Find() method.
+- Added a helper class for executing asynchronous methods synchronously.
+
 **June 27, 2019 - 7.0.0 Redesigned the Identity services to make them easier to use**
 
 - Standardised the Identity user framework to make it more intuitive and easier to implement based upon Microsoft conventions.


### PR DESCRIPTION
- Enhanced the repository layer to support bulk operations on delete and update.
- Removed operations that delete objects by unique identifier from the repository and service layers.
- Resolved issue regarding the use of "includes" with the DbSet<T>.Find() method.
- Added a helper class for executing asynchronous methods synchronously.