### PR TITLE
Minor change to the audit decorator

### DIFF
--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AspNet/Tardigrade.Framework.AspNet.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AspNet/Tardigrade.Framework.AspNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net461</TargetFrameworks>
-    <Version>4.1.0</Version>
+    <Version>4.1.1</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library (ASP.NET Integration)</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AuditNET/Decorators/ObjectServiceAuditDecorator.cs
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AuditNET/Decorators/ObjectServiceAuditDecorator.cs
@@ -94,7 +94,7 @@ namespace Tardigrade.Framework.AuditNET.Decorators
         {
             IEnumerable<T> created = default(IEnumerable<T>);
 
-            using (AuditScope auditScope = AuditScope.Create($"{typeof(T).Name}+:Create", () => created))
+            using (AuditScope auditScope = AuditScope.Create($"{typeof(T).Name}:Create+", () => created))
             {
                 auditScope.Event.Target.Type = $"{objs.GetType()}";
                 created = decoratee.Create(objs);
@@ -131,7 +131,7 @@ namespace Tardigrade.Framework.AuditNET.Decorators
 
             try
             {
-                auditScope = await AuditScope.CreateAsync($"{typeof(T).Name}+:Create", () => created);
+                auditScope = await AuditScope.CreateAsync($"{typeof(T).Name}:Create+", () => created);
                 auditScope.Event.Target.Type = $"{objs.GetType()}";
                 created = await decoratee.CreateAsync(objs, cancellationToken);
             }
@@ -264,7 +264,7 @@ namespace Tardigrade.Framework.AuditNET.Decorators
             // Due to size constraints, only audit the number of objects retrieved rather than the objects themselves.
             AuditScopeOptions options = new AuditScopeOptions
             {
-                EventType = $"{typeof(T).Name}+:Retrieve",
+                EventType = $"{typeof(T).Name}:Retrieve+",
                 ExtraFields = new { Count = retrieved.Count() },
                 AuditEvent = new AuditEvent { Target = new AuditTarget() }
             };
@@ -313,7 +313,7 @@ namespace Tardigrade.Framework.AuditNET.Decorators
             // Due to size constraints, only audit the number of objects retrieved rather than the objects themselves.
             AuditScopeOptions options = new AuditScopeOptions
             {
-                EventType = $"{typeof(T).Name}+:Retrieve",
+                EventType = $"{typeof(T).Name}:Retrieve+",
                 ExtraFields = new { Count = retrieved.Count() },
                 AuditEvent = new AuditEvent { Target = new AuditTarget() }
             };

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.AuditNET/Tardigrade.Framework.AuditNET.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.AuditNET/Tardigrade.Framework.AuditNET.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library (Audit.NET Integration)</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/Tardigrade.Framework.EntityFramework.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.EntityFramework/Tardigrade.Framework.EntityFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net461</TargetFrameworks>
-    <Version>9.1.0</Version>
+    <Version>9.1.1</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library (Entity Framework Integration)</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.RestSharp/Tardigrade.Framework.RestSharp.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.RestSharp/Tardigrade.Framework.RestSharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library (RestSharp Integration)</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/Code/Tardigrade.Framework/Tardigrade.Framework.SimpleInjector/Tardigrade.Framework.SimpleInjector.csproj
+++ b/Code/Tardigrade.Framework/Tardigrade.Framework.SimpleInjector/Tardigrade.Framework.SimpleInjector.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0;net472;net461</TargetFrameworks>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
     <Authors>Rafidzal Rafiq</Authors>
     <Product>Tardigrade Framework Library SimpleInjector Integration)</Product>
     <Description>Software framework for supporting coding best practices.</Description>

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Framework for supporting coding best practices.
 
 ## Version control history
 
+**Mar 11, 2020 - 10.3.0 Minor change to the audit decorator**
+
+- Minor change to event types defined in the Audit.NET object service audit decorator.
+- Updated NuGet package version numbers that were missed in the last release, as well as references to them.
+
 **Mar 5, 2020 - 10.2.0 Created read-only repository interface**
 
 - Created a read-only repository interface and refactored the Azure Storage, Entity Framework and Entity Framework Core repository implementations accordingly.


### PR DESCRIPTION
- Minor change to event types defined in the Audit.NET object service audit decorator.
- Updated NuGet package version numbers that were missed in the last release, as well as references to them.